### PR TITLE
Add gadget mode example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   global:
     - ELIXIR_VERSION=1.4.5 ERLANG_VERSION=19.3
   matrix:
+    - MIX_TARGET=rpi0
     - MIX_TARGET=rpi
     - MIX_TARGET=rpi2
     - MIX_TARGET=rpi3
@@ -69,6 +70,11 @@ script:
   - popd
   - if [[ "$MIX_TARGET" == rpi* ]]; then
       pushd neopixel;
+      mix do deps.get, firmware --verbosity=verbose;
+      popd;
+    fi
+  - if [[ "$MIX_TARGET" == rpi0 ]]; then
+      pushd hello_gadget;
       mix do deps.get, firmware --verbosity=verbose;
       popd;
     fi

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Nerves Examples
 [![Build Status](https://travis-ci.org/nerves-project/nerves-examples.png?branch=master)](https://travis-ci.org/nerves-project/nerves-examples)
 
 This repository contains several Nerves example projects as sub-directories.
-Most of these projects should work on all of the [Nerves supported targets](https://hexdocs.pm/nerves/targets.html).
-One notable exception is the `neopixel` example, which depends on the Raspberry Pi hardware and won't work on other platforms.
+Aside from the `neopixel` and `hello_gadget` examples, most of these projects should work on all of the [Nerves supported targets](https://hexdocs.pm/nerves/targets.html).
 
 For detailed information on how to build an example, see the `README.md` in each application's root directory.
 
 * [`blinky`](https://github.com/nerves-project/nerves-examples/blob/master/blinky/README.md)
+* [`hello_gadget`](https://github.com/nerves-project/nerves-examples/blob/master/hello_gadget/README.md)
 * [`hello_gpio`](https://github.com/nerves-project/nerves-examples/blob/master/hello_gpio/README.md)
 * [`hello_gpio_input`](https://github.com/nerves-project/nerves-examples/blob/master/hello_gpio_input/README.md)
 * [`hello_leds`](https://github.com/nerves-project/nerves-examples/blob/master/hello_leds/README.md)

--- a/hello_gadget/.gitignore
+++ b/hello_gadget/.gitignore
@@ -1,0 +1,13 @@
+# App artifacts
+/_build
+/db
+/deps
+/*.ez
+/mix.lock
+
+# Nerves artifacts
+/_images
+/.nerves
+
+# Generate on crash by the VM
+erl_crash.dump

--- a/hello_gadget/README.md
+++ b/hello_gadget/README.md
@@ -1,0 +1,72 @@
+# hello_gadget
+
+This is an example of using
+[nerves_init_gadget](https://github.com/fhunleth/nerves_init_gadget) to
+initialize a simple application that runs on a board supporting USB gadget mode.
+Currently this is limited to the Raspberry Pi Zero and Raspberry Pi Zero W.
+
+## Getting started
+
+This image supports firmware updates using `nerves_firmware_ssh`. To use this
+feature, the SSH public keys that are allowed to update the firmware need to be
+added to `config/config.exs`. This process is similar to adding a key to an
+`authorized_keys` file on a server. See the `config/config.exs` for where to put
+your key.
+
+Then, in this directory, run the following to build and program a MicroSD card:
+
+```
+MIX_TARGET=rpi0 mix deps.get
+MIX_TARGET=rpi0 mix firmware
+
+# Insert a MicroSD Card into a card reader and "burn" it
+MIX_TARGET=rpi0 mix firmware.burn
+```
+Now plug the MicroSD card into a Raspberry Pi Zero. Connect your laptop or
+computer to the Raspberry Pi Zero's USB port that's labeled "USB" (not the one
+labeled "PWR".)
+
+## Accessing an IEx prompt
+
+The IEx prompt is exposed over a virtual serial port through the USB cable. When
+the Raspberry Pi Zero boots you may see USB serial port driver get loaded on
+your computer. Connect to it via a terminal emulator like "picocom" or "screen".
+It should be something like the following:
+
+```
+picocom /dev/tty.usbmodem*
+```
+If you're familiar with doing this, you'll notice that the baud rate isn't
+specified. It is ignored by the driver, so any baud rate should work.
+
+## Networking
+
+This image also exposes a virtual Ethernet interface. This interface only
+supports link local IP addresses. This means that no DHCP server is needed. It
+should just come up and work. The firmware runs an mDNS server that responds to
+requests for `nerves.local`. Trying pinging it:
+```
+ping nerves.local
+```
+
+## Firmware updates
+
+Firmware updates use an A/B system for upgrades. First the firmware is loaded to
+the A slot (or partition) and then the next upgrade is written to the B slot.
+When that completes, the system reboots and the B slot becomes active. The next
+upgrade writes to the A slot and so on.
+
+To run an upgrade, make sure that you can ping the device and then run the
+following:
+```
+MIX_TARGET=rpi0 mix firmware.push nerves.local
+```
+You may need to pass `--passphrase <your passphrase>` if you private key is
+password protected.
+
+## Learn more about Nerves
+
+  * Official docs: https://hexdocs.pm/nerves/getting-started.html
+  * Official website: http://www.nerves-project.org/
+  * Discussion Slack elixir-lang #nerves ([Invite](https://elixir-slackin.herokuapp.com/))
+  * Source: https://github.com/nerves-project/nerves

--- a/hello_gadget/config/config.exs
+++ b/hello_gadget/config/config.exs
@@ -1,0 +1,25 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+#
+# This configuration file is loaded before any dependency and
+# is restricted to this project.
+use Mix.Config
+
+# Boot the bootloader first and have it start our app.
+config :bootloader,
+  init: [:nerves_init_gadget],
+  app: :hello_gadget
+
+# You can also manually add your keys below if ~/.ssh/id_rsa.pub
+# doesn't work for you.
+config :nerves_firmware_ssh,
+  authorized_keys: [
+    File.read!(Path.join(System.user_home!, ".ssh/id_rsa.pub"))
+  ]
+
+# Import target specific config. This must remain at the bottom
+# of this file so it overrides the configuration defined above.
+# Uncomment to use target specific configurations
+
+# import_config "#{Mix.Project.config[:target]}.exs"
+

--- a/hello_gadget/lib/hello_gadget.ex
+++ b/hello_gadget/lib/hello_gadget.ex
@@ -1,0 +1,3 @@
+defmodule HelloGadget do
+
+end

--- a/hello_gadget/lib/hello_gadget/application.ex
+++ b/hello_gadget/lib/hello_gadget/application.ex
@@ -1,0 +1,18 @@
+defmodule HelloGadget.Application do
+  use Application
+
+  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # for more information on OTP Applications
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    # Define workers and child supervisors to be supervised
+    children = [
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Zero.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/hello_gadget/mix.exs
+++ b/hello_gadget/mix.exs
@@ -1,0 +1,78 @@
+defmodule HelloGadget.Mixfile do
+  use Mix.Project
+
+  @target System.get_env("MIX_TARGET") || "host"
+
+  Mix.shell.info([:green, """
+  Mix environment
+    MIX_TARGET:   #{@target}
+    MIX_ENV:      #{Mix.env}
+  """, :reset])
+
+  def project do
+    [app: :hello_gadget,
+     version: "0.1.0",
+     elixir: "~> 1.4.0",
+     target: @target,
+     archives: [nerves_bootstrap: "~> 0.5"],
+     deps_path: "deps/#{@target}",
+     build_path: "_build/#{@target}",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     aliases: aliases(@target),
+     deps: deps()]
+  end
+
+  # Configuration for the OTP application.
+  #
+  # Type `mix help compile.app` for more information.
+  def application, do: application(@target)
+
+  # Specify target specific application configurations
+  # It is common that the application start function will start and supervise
+  # applications which could cause the host to fail. Because of this, we only
+  # invoke HelloGadget.start/2 when running on a target.
+  def application("host") do
+    [extra_applications: [:logger]]
+  end
+  def application(_target) do
+    [mod: {HelloGadget.Application, []},
+     extra_applications: [:logger]]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:my_dep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  def deps do
+    [{:nerves, "~> 0.7", runtime: false}] ++
+    deps(@target)
+  end
+
+  # Specify target specific dependencies
+  def deps("host"), do: []
+  def deps(target) do
+    [ system(target),
+     {:nerves_runtime, "~> 0.4"},
+     {:bootloader, "~> 0.1"},
+     {:nerves_init_gadget, "~> 0.1"}]
+  end
+
+  # Specify the version of the System to use for each target
+  def system("rpi0"), do:       {:nerves_system_rpi0,       "~> 0.15", runtime: false}
+  def system("bbb"), do:        {:nerves_system_bbb,        "~> 0.15", runtime: false}
+  def system(target), do:       Mix.raise "Unknown MIX_TARGET: #{target}"
+
+  # We do not invoke the Nerves Env when running on the Host
+  def aliases("host"), do: []
+  def aliases(_target) do
+    ["deps.precompile": ["nerves.precompile", "deps.precompile"],
+     "deps.loadpaths":  ["deps.loadpaths", "nerves.loadpaths"]]
+  end
+
+end

--- a/hello_gadget/rel/config.exs
+++ b/hello_gadget/rel/config.exs
@@ -1,0 +1,40 @@
+use Mix.Releases.Config,
+    # This sets the default release built by `mix release`
+    default_release: :default,
+    # This sets the default environment used by `mix release`
+    default_environment: :dev
+
+# For a full list of config options for both releases
+# and environments, visit https://hexdocs.pm/distillery/configuration.html
+
+
+# You may define one or more environments in this file,
+# an environment's settings will override those of a release
+# when building in that environment, this combination of release
+# and environment configuration is called a profile
+
+environment :dev do
+  set cookie: :"N7=;||Lz5e!U{m:{N=@RkF*8pj)3(sPxuINmfs[@xV[uQAg!Gbsx%ka`7c7V[WBz"
+end
+
+environment :prod do
+  set cookie: :"N7=;||Lz5e!U{m:{N=@RkF*8pj)3(sPxuINmfs[@xV[uQAg!Gbsx%ka`7c7V[WBz"
+end
+
+# You may define one or more releases in this file.
+# If you have not set a default release, or selected one
+# when running `mix release`, the first release in the file
+# will be used by default
+
+release :hello_gadget do
+  set version: current_version(:hello_gadget)
+  plugin Bootloader.Plugin
+  if System.get_env("NERVES_SYSTEM") do
+    set dev_mode: false
+    set include_src: false
+    set include_erts: System.get_env("ERL_LIB_DIR")
+    set include_system_libs: System.get_env("ERL_SYSTEM_LIB_DIR")
+    set vm_args: "rel/vm.args"
+  end
+end
+

--- a/hello_gadget/rel/vm.args
+++ b/hello_gadget/rel/vm.args
@@ -1,0 +1,25 @@
+## Add custom options here
+
+## Distributed Erlang Options
+##  The cookie needs to be configured prior to vm boot for
+##  for read only filesystem.
+
+# -name hello_gadget@0.0.0.0
+-setcookie EKZRklVBKZlmh7bspKfd/6n50WZTTj7klKJThTYd0nZt9Fvf5XOIaHIOU/ZH9ZAn
+
+## Use Ctrl-C to interrupt the current shell rather than invoking the emulator's
+## break handler and possibly exiting the VM.
++Bc
+
+## Save the shell history between reboots
+## See http://erlang.org/doc/man/kernel_app.html for additional options
+-kernel shell_history enabled
+
+## Start the Elixir shell
+
+-noshell
+-user Elixir.IEx.CLI
+
+## Options added after -extra are interpreted as plain arguments and
+## can be retrieved using :init.get_plain_arguments().
+-extra --no-halt


### PR DESCRIPTION
This is an example of how to use the USB gadget mode interface on a Raspberry Pi Zero. Once `nerves_system_bbb` supports gadget mode, it will work on that platform as well.