### PR TITLE
Fixes links in `hello_phoenix/README.md`

### DIFF
--- a/hello_phoenix/README.md
+++ b/hello_phoenix/README.md
@@ -37,8 +37,8 @@ mix firmware
 mix firmware.burn
 ```
 
-[Phoenix Framework](http://www.phoenixframework.org/)
-[Poncho Projects](http://embedded-elixir.com/post/2017-05-19-poncho-projects/)
+[Phoenix Framework]: http://www.phoenixframework.org/
+[Poncho Projects]: http://embedded-elixir.com/post/2017-05-19-poncho-projects/
 
 ## Learn More
 


### PR DESCRIPTION
The links to phoenix and the poncho project blog post were in the wrong format, so they weren't showing up properly. Changed to use the reference link format.