### PR TITLE
Add simple Erlang Distribution example to `hello_network`

### DIFF
--- a/hello_network/README.md
+++ b/hello_network/README.md
@@ -82,6 +82,21 @@ iex(1)> HelloNetwork.test_dns()
  {:hostent, 'nerves-project.org', [], :inet, 4,
   [{192, 30, 252, 154}, {192, 30, 252, 153}]}}
 ```
+
+### Distribution and the Remote Shell
+
+Whenever the IP address of the device changes, it restarts the Erlang
+Distribution node to set its name to `:hello_network@#{ip}` so that you can
+remotely connect to it over the network. It will log the node name to the
+console, but if you do not have a screen or serial console cable attached, you
+can also determine the node name based on the IP address assigned by your DHCP
+server. Assuming your development computer's IP address is `10.0.0.100` and your
+Nerves device is `10.0.0.200`, you would connect to the remote shell as follows:
+
+```bash
+iex --name console@10.0.0.100 --hidden --remsh hello_network@10.0.0.200 --cookie ZKf4a0QT7EHzWCwLey
+```
+
 ## Learn More
 
   * Official docs: https://hexdocs.pm/nerves/getting-started.html

--- a/hello_network/lib/hello_network.ex
+++ b/hello_network/lib/hello_network.ex
@@ -46,7 +46,10 @@ defmodule HelloNetwork do
   def handle_info({:system_registry, :global, registry}, state) do
     ip = get_in registry, [:state, :network_interface, state.interface, :ipv4_address]
     if ip != state.ip_address do
-      Logger.info "IP ADDRESS CHANGED: #{ip}"
+      node_name = :"hello_network@#{ip}"
+      Logger.info "IP address changed. Setting node name to: #{node_name}"
+      :net_kernel.stop()
+      :net_kernel.start([node_name])
     end
 
     connected = match?({:ok, {:hostent, 'nerves-project.org', [], :inet, 4, _}}, test_dns())

--- a/hello_network/rel/vm.args
+++ b/hello_network/rel/vm.args
@@ -5,7 +5,7 @@
 ##  for read only filesystem.
 
 # -name hello_network@0.0.0.0
--setcookie ZKf4a0QT7EHzWCwLey/cur+yN2BPyBSDtUFkyCjeMuAW+peD3x/xyqZzqByVHPWq
+-setcookie ZKf4a0QT7EHzWCwLey
 
 ## Use Ctrl-C to interrupt the current shell rather than invoking the emulator's
 ## break handler and possibly exiting the VM.


### PR DESCRIPTION
I was a little hesitant to include this example since it's probably not a great idea to _actually_ use Erlang Distribution like this in a production system, but people keep asking how to do it and it's certainly handy for development. Let me know how you feel about that. Should we just demonstrate how to set up an SSH-based shell instead of using Distribution?

I don't have access to hardware right now to verify this, but I'll give it a try in a few days before I hit the merge button.

Fixes #45.