### PR TITLE
Enable heart on all examples

### DIFF
--- a/blinky/rel/vm.args
+++ b/blinky/rel/vm.args
@@ -16,7 +16,7 @@
 -kernel shell_history enabled
 
 ## Enable heartbeat monitoring of the Erlang runtime system
-#-heart -env HEART_BEAT_TIMEOUT 30
+-heart -env HEART_BEAT_TIMEOUT 30
 
 ## Start the Elixir shell
 

--- a/hello_gpio/rel/vm.args
+++ b/hello_gpio/rel/vm.args
@@ -16,7 +16,7 @@
 -kernel shell_history enabled
 
 ## Enable heartbeat monitoring of the Erlang runtime system
-#-heart -env HEART_BEAT_TIMEOUT 30
+-heart -env HEART_BEAT_TIMEOUT 30
 
 ## Start the Elixir shell
 

--- a/hello_leds/rel/vm.args
+++ b/hello_leds/rel/vm.args
@@ -16,7 +16,7 @@
 -kernel shell_history enabled
 
 ## Enable heartbeat monitoring of the Erlang runtime system
-#-heart -env HEART_BEAT_TIMEOUT 30
+-heart -env HEART_BEAT_TIMEOUT 30
 
 ## Start the Elixir shell
 

--- a/hello_network/rel/vm.args
+++ b/hello_network/rel/vm.args
@@ -16,7 +16,7 @@
 -kernel shell_history enabled
 
 ## Enable heartbeat monitoring of the Erlang runtime system
-#-heart -env HEART_BEAT_TIMEOUT 30
+-heart -env HEART_BEAT_TIMEOUT 30
 
 ## Start the Elixir shell
 

--- a/hello_phoenix/firmware/rel/vm.args
+++ b/hello_phoenix/firmware/rel/vm.args
@@ -16,7 +16,7 @@
 -kernel shell_history enabled
 
 ## Enable heartbeat monitoring of the Erlang runtime system
-#-heart -env HEART_BEAT_TIMEOUT 30
+-heart -env HEART_BEAT_TIMEOUT 30
 
 ## Start the Elixir shell
 


### PR DESCRIPTION
Heart has been working really well and it demonstrates one of the reliability features of the Nerves platform. Also, the new bbb builds require it since the hw watchdog is started in the Linux kernel boot sequence.