### PR TITLE
Retry deps get on failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,13 @@ build: &build
         name: Build Project
         command: |
           cd $MIX_PROJECT
-          mix deps.get
+          n=0
+          until [ $n -ge 5 ]; do
+            mix deps.get && break
+            n=$((n+1))
+            echo "Error while fetching deps. Retrying in 5 seconds"
+            sleep 5
+          done
           mix firmware
 
 jobs:


### PR DESCRIPTION
Downloading artifacts during `deps.get` could sometimes fail due to corrupt downloads. This PR will allow the job to retry after 5 seconds for up to 5 times. 

We can see how this catches these cases in the following job run. https://circleci.com/gh/nerves-project/nerves_examples/3283

```
 => Trying https://github.com/nerves-project/nerves_system_rpi2/releases/download/v1.5.1/nerves_system_rpi2-portable-1.5.1-D48014E.tar.gz
     Invalid or corrupt file
  => Trying https://github.com/nerves-project/nerves_system_rpi2/releases/download/v1.5.1/nerves_system_rpi2-portable-1.5.1-D48014ECE742B0DA1E20A2C107CC92178F891E15CCAECA1CB9C3CDBF9CCAB9E2.tar.gz
     Status 404 Not Found
** (Mix) Nerves encountered errors while validating artifact download.

gzip: /root/.nerves/dl/nerves_system_rpi2-portable-1.5.1-D48014E.tar.gz: unexpected end of file


Error while fetching deps. Retrying in 5 seconds
Resolving Hex dependencies...
Dependency resolution completed:
Unchanged:
  artificery 0.2.6
  distillery 2.0.10
  dns 2.1.2
  elixir_make 0.4.2
  mdns 1.0.2
  nerves 1.3.2
  nerves_firmware_ssh 0.3.3
  nerves_init_gadget 0.5.2
  nerves_network 0.3.7
  nerves_network_interface 0.4.4
  nerves_runtime 0.8.0
  nerves_system_br 1.5.3
  nerves_system_linter 0.3.0
  nerves_system_rpi2 1.5.1
  nerves_toolchain_arm_unknown_linux_gnueabihf 1.1.0
  nerves_toolchain_ctng 1.5.0
  nerves_wpa_supplicant 0.3.3
  one_dhcpd 0.2.0
  ring_logger 0.6.0
  shoehorn 0.4.0
  socket 0.3.13
  system_registry 0.8.0
All dependencies up to date

Nerves environment
  MIX_TARGET:   rpi2
  MIX_ENV:      dev

Resolving Nerves artifacts...
  Resolving nerves_system_rpi2
  => Trying https://github.com/nerves-project/nerves_system_rpi2/releases/download/v1.5.1/nerves_system_rpi2-portable-1.5.1-D48014E.tar.gz
  => Success
  Resolving nerves_toolchain_arm_unknown_linux_gnueabihf
  => Trying https://github.com/nerves-project/toolchains/releases/download/v1.1.0/nerves_toolchain_arm_unknown_linux_gnueabihf-linux_x86_64-1.1.0-2305AD8.tar.xz
  => Success
```
