### PR TITLE
Use nerves_init_gadget to configure networking

### DIFF
--- a/hello_network/README.md
+++ b/hello_network/README.md
@@ -3,8 +3,8 @@
 This example shows how to connect your Nerves device to the network using wired
 or wireless Ethernet. By default, the configuration assumes that you'll be
 connecting using the wired Ethernet interface `eth0`, but you can change the
-`:interface` option in `config/config.exs` to choose another interface (such as
-`:wlan0` for WiFi or `:usb0` for USB gadget-mode Ethernet). The targets with
+`:ifname` option in `config/config.exs` to choose another interface (such as
+`"wlan0"` for WiFi or `"usb0"` for USB gadget-mode Ethernet). The targets with
 built-in WiFi hardware (such as `rpi3` and `rpi0` on a Zero W) will work with
 their built in WiFi, but you can also use a variety of popular USB WiFi dongles
 on other targets.
@@ -28,17 +28,20 @@ mix firmware.burn
 
 ### How to Use the WiFi Interface
 
-Configure the application settings to use your WiFi interface (`:wlan0`) instead
-of your wired interface (`:eth0`):
+Configure the application settings to use your WiFi interface (`"wlan0"`) instead
+of your wired interface (`"eth0"`):
 
 ```elixir
 # config/config.exs
 
 # ...
 
-#config :hello_network, interface: :eth0
-config :hello_network, interface: :wlan0
-#config :hello_network, interface: :usb0
+config :nerves_init_gadget,
+  node_name: :hello_network,
+  mdns_domain: "hello_network.local",
+  address_method: :dhcp,
+  # ifname: "eth0"
+  ifname: "wlan0"
 
 key_mgmt = System.get_env("NERVES_NETWORK_KEY_MGMT") || "WPA-PSK"
 
@@ -47,9 +50,6 @@ config :nerves_network, :default,
     ssid: System.get_env("NERVES_NETWORK_SSID"),
     psk: System.get_env("NERVES_NETWORK_PSK"),
     key_mgmt: String.to_atom(key_mgmt)
-  ],
-  eth0: [
-    ipv4_address_method: :dhcp
   ]
 
 # ...

--- a/hello_network/config/config.exs
+++ b/hello_network/config/config.exs
@@ -10,11 +10,22 @@ use Mix.Config
 
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
-# Uncomment the following line for the interface you intend to use,
-# if not the wired :eth0 interface.
-config :hello_network, interface: :eth0
-# config :hello_network, interface: :wlan0
-# config :hello_network, interface: :usb0
+# Configure nerves_init_gadget for the interface you intend to use
+# See https://hexdocs.pm/nerves_init_gadget/readme.html for more information.
+
+# Set a mdns domain and node_name to be able to remsh into the device.
+config :nerves_init_gadget,
+  node_name: :hello_network,
+  mdns_domain: "hello_network.local",
+  address_method: :dhcp,
+  ifname: "eth0"
+  # ifname: "wlan0"
+
+  # To use USB gadget mode on supported devices:
+  # ifname: "usb0",
+  # address_method: :dhcpd
+
+# Configure wireless settings
 
 key_mgmt = System.get_env("NERVES_NETWORK_KEY_MGMT") || "WPA-PSK"
 
@@ -23,9 +34,6 @@ config :nerves_network, :default,
     ssid: System.get_env("NERVES_NETWORK_SSID"),
     psk: System.get_env("NERVES_NETWORK_PSK"),
     key_mgmt: String.to_atom(key_mgmt)
-  ],
-  eth0: [
-    ipv4_address_method: :dhcp
   ]
 
 # Use shoehorn to start the main application. See the shoehorn
@@ -53,23 +61,6 @@ config :nerves_firmware_ssh,
   authorized_keys: [
     File.read!(key)
   ]
-
-# Configure nerves_init_gadget.
-# See https://hexdocs.pm/nerves_init_gadget/readme.html for more information.
-
-# Set a mdns domain and node_name to be able to remsh into the device.
-config :nerves_init_gadget,
-  node_name: :hello_network,
-  mdns_domain: "hello_network.local",
-  ifname: "usb0",
-  address_method: :dhcpd
-
-# For Devices that don't support USB gadget mode (such as Raspberry Pi 3),
-# you may want to change the primary network interface or IP address method:
-#
-# config :nerves_init_gadget,
-#  address_method: :dhcp,
-#  ifname: "eth0"
 
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.


### PR DESCRIPTION
I tried to keep changes to a minimum. I was able to test wireless with an rpi0 and wired with an rpi3. Please let me know if any changes are needed.