### PR TITLE
Fix link to nerves-project.org.

### DIFF
--- a/hello_gpio/README.md
+++ b/hello_gpio/README.md
@@ -48,6 +48,6 @@ mix firmware.burn
 ## Learn More
 
 * Official docs: https://hexdocs.pm/nerves/getting-started.html
-* Official website: http://www.nerves-project.org/
+* Official website: http://nerves-project.org/
 * Discussion Slack elixir-lang #nerves ([Invite](https://elixir-slackin.herokuapp.com/))
 * Source: https://github.com/nerves-project/nerves


### PR DESCRIPTION
Link was taking browser to a "www.nerves-project.org: 4003". error page of some kind.