### PR TITLE
Consistently assume rpi0 target by default

### DIFF
--- a/blinky/README.md
+++ b/blinky/README.md
@@ -22,7 +22,7 @@ The built-in user-controllable LEDs will blink, as configured for your target ha
   a. Note: during the boot process the LED may blink sporadically
 
 ```bash
-export MIX_TARGET=rpi3
+export MIX_TARGET=rpi0
 mix deps.get
 mix firmware
 mix firmware.burn

--- a/hello_gpio/README.md
+++ b/hello_gpio/README.md
@@ -39,7 +39,7 @@ Pi as shown in the diagram at [pinout.xyz](https://pinout.xyz).
     of the switch
 
 ```bash
-export MIX_TARGET=rpi3
+export MIX_TARGET=rpi0
 mix deps.get
 mix firmware
 mix firmware.burn

--- a/hello_leds/README.md
+++ b/hello_leds/README.md
@@ -22,7 +22,7 @@ The built-in user-controllable LEDs will blink, as configured for your target ha
 6. After about 5 seconds, the configured LED(s) should start blinking
 
 ``` bash
-export MIX_TARGET=rpi3
+export MIX_TARGET=rpi0
 mix deps.get
 mix firmware
 mix firmware.burn


### PR DESCRIPTION
I realized just after #117 got merged that some of this stuff wasn't consistent / updated recently.