### PR TITLE
Pin the circle ci container to nerves_system_br:1.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ elixir_version: &elixir_version
 defaults: &defaults
   working_directory: /nerves/build
   docker:
-    - image: nervesproject/nerves_system_br:latest
+    - image: nervesproject/nerves_system_br:1.7.2
 
 install_elixir: &install_elixir
   run:


### PR DESCRIPTION
Using nerves_system_br:latest decouples from the version declared in the system mix file and causes potential host / target version mismatches.