### PR TITLE
fix maybe_start_wifi_wizard() logic in hello_wifi

### DIFF
--- a/hello_wifi/lib/hello_wifi.ex
+++ b/hello_wifi/lib/hello_wifi.ex
@@ -5,8 +5,9 @@ defmodule HelloWiFi do
 
   @spec start(Application.start_type(), any()) :: {:error, any} | {:ok, pid()}
   def start(_type, _args) do
-    VintageNet.configured_interfaces()
-    |> Enum.any?(&(&1 =~ ~r/^wlan/))
+    VintageNet.configured_interfaces() 
+    |> Enum.filter(&(&1 =~ ~r/^wlan/)) 
+    |> Enum.any?(&(VintageNet.get_configuration(&1).vintage_net_wifi.networks != []))
     |> maybe_start_wifi_wizard()
 
     gpio_pin = Application.get_env(:hello_wifi, :button_pin, 17)


### PR DESCRIPTION
the current logic always returns true.. the logic is unused in the example - yet the user quickly want to enable the logic..

freshly formatted and "burned" sd card:
```
iex(13)> VintageNet.configured_interfaces()
["eth0", "usb0", "wlan0"]

```
VintageNet.info gives:
...
```
Interface wlan0
  Type: VintageNetWiFi
  Present: true
  State: :configured (0:01:02)
  Connection: :disconnected (0:01:03)
  Configuration:
    %{
      ipv4: %{method: :disabled},
      type: VintageNetWiFi,
      vintage_net_wifi: %{networks: []}
    }

```
so from the get go wlanX is always "configured" even when no network(s) is setup..

fully understand `VintageNet.get_configuration(&1).vintage_net_wifi.networks != []` is a mouthful, but I'm not familiar with a better api?