### PR TITLE
Refactor logic for starting the WiFi wizard

### DIFF
--- a/hello_wifi/lib/hello_wifi.ex
+++ b/hello_wifi/lib/hello_wifi.ex
@@ -3,11 +3,11 @@ defmodule HelloWiFi do
 
   require Logger
 
+  @ifname "wlan0"
+
   @spec start(Application.start_type(), any()) :: {:error, any} | {:ok, pid()}
   def start(_type, _args) do
-    VintageNet.configured_interfaces()
-    |> Enum.any?(&(&1 =~ ~r/^wlan/))
-    |> maybe_start_wifi_wizard()
+    maybe_start_wifi_wizard()
 
     gpio_pin = Application.get_env(:hello_wifi, :button_pin, 17)
 
@@ -27,21 +27,52 @@ defmodule HelloWiFi do
     Logger.info("[HelloWiFi] - WiFi Wizard stopped")
   end
 
-  defp maybe_start_wifi_wizard(_wifi_configured? = true) do
-    # By this point we know there is a wlan interface available
-    # and already configured. This would normally mean that you
-    # should then skip starting the WiFi wizard here so that
-    # the device doesn't start the WiFi wizard after every
-    # reboot.
-    #
-    # However, for the example we want to always run the
-    # WiFi wizard on startup. Comment/remove the function below
-    # if you want a more typical experience skipping the wizard
-    # after it has been configured once.
-    VintageNetWizard.run_wizard(on_exit: {__MODULE__, :on_wizard_exit, []})
+  defp maybe_start_wifi_wizard() do
+    with true <- has_wifi?() || :no_wifi,
+         true <- wifi_configured?() || :not_configured,
+         true <- has_networks?() || :no_networks do
+      # By this point we know there is a wlan interface available
+      # and already configured with networks. This would normally
+      # mean that you should then skip starting the WiFi wizard
+      # here so that the device doesn't start the WiFi wizard after
+      # every reboot.
+      #
+      # However, for the example we want to always run the
+      # WiFi wizard on startup. Comment/remove the function below
+      # if you want a more typical experience skipping the wizard
+      # after it has been configured once.
+      VintageNetWizard.run_wizard(on_exit: {__MODULE__, :on_wizard_exit, []})
+    else
+      :no_wifi ->
+        Logger.error(
+          "[#{inspect(__MODULE__)}] Device does not support WiFi - Skipping wizard start"
+        )
+
+      status ->
+        info_message(status)
+        VintageNetWizard.run_wizard(on_exit: {__MODULE__, :on_wizard_exit, []})
+    end
   end
 
-  defp maybe_start_wifi_wizard(_wifi_not_configured) do
-    VintageNetWizard.run_wizard(on_exit: {__MODULE__, :on_wizard_exit, []})
+  defp has_wifi?() do
+    @ifname in VintageNet.all_interfaces()
+  end
+
+  defp wifi_configured?() do
+    @ifname in VintageNet.configured_interfaces()
+  end
+
+  defp has_networks?() do
+    VintageNet.get_configuration(@ifname).vintage_net_wifi.networks != []
+  end
+
+  defp info_message(status) do
+    msg =
+      case status do
+        :not_configured -> "WiFi has not been configured"
+        :no_networks -> "WiFi was configured without any networks"
+      end
+
+    Logger.info("[#{inspect(__MODULE__)}] #{msg} - Starting WiFi Wizard")
   end
 end


### PR DESCRIPTION
Thanks to @petermm for bringing up a fault in the wizard start logic which would consider WiFi "configured" even if there are not networks saved (which is still valid configuration in VintageNet)

This addresses the concerns brought up in https://github.com/nerves-project/nerves_examples/pull/147 but after discussing offline, we ultimately decided just to take this opportunity to refactor with more descriptive functions to make the logic more clear and handle this specific use-case as well.