### PR TITLE
Removed Phoenix config from firmware app

### DIFF
--- a/hello_phoenix/firmware/config/config.exs
+++ b/hello_phoenix/firmware/config/config.exs
@@ -23,8 +23,6 @@ config :nerves, source_date_epoch: "1591379755"
 
 config :logger, backends: [RingLogger]
 
-config :phoenix, :json_library, Jason
-
 if Mix.target() != :host do
   import_config "target.exs"
 end


### PR DESCRIPTION
The config for phoenix is not relevant in config.exs in firmware app. It's already included in ui app.