### PR TITLE
Update the release config per new template

### DIFF
--- a/blinky/mix.exs
+++ b/blinky/mix.exs
@@ -57,10 +57,12 @@ defmodule Blinky.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end

--- a/hello_erlang/mix.exs
+++ b/hello_erlang/mix.exs
@@ -55,10 +55,12 @@ defmodule HelloErlang.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end

--- a/hello_gpio/mix.exs
+++ b/hello_gpio/mix.exs
@@ -57,10 +57,12 @@ defmodule HelloGpio.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end

--- a/hello_leds/mix.exs
+++ b/hello_leds/mix.exs
@@ -57,10 +57,12 @@ defmodule HelloLeds.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end

--- a/hello_lfe/mix.exs
+++ b/hello_lfe/mix.exs
@@ -57,10 +57,12 @@ defmodule HelloLfe.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end

--- a/hello_phoenix/firmware/mix.exs
+++ b/hello_phoenix/firmware/mix.exs
@@ -57,10 +57,12 @@ defmodule Firmware.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end

--- a/hello_wifi/mix.exs
+++ b/hello_wifi/mix.exs
@@ -58,10 +58,12 @@ defmodule HelloWiFi.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end

--- a/minimal/mix.exs
+++ b/minimal/mix.exs
@@ -54,10 +54,12 @@ defmodule Minimal.MixProject do
   def release do
     [
       overwrite: true,
+      # Erlang distribution is not started automatically.
+      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod or [keep: ["Docs"]]
     ]
   end
 end


### PR DESCRIPTION
This will reduce the firmware size for most users by stripping
everything but the docs for dev builds.
