### PR TITLE
Update VintageNetWiFi config to use :networks key

### DIFF
--- a/hello_phoenix/firmware/config/target.exs
+++ b/hello_phoenix/firmware/config/target.exs
@@ -76,9 +76,13 @@ config :vintage_net,
      %{
        type: VintageNetWiFi,
        vintage_net_wifi: %{
-         key_mgmt: String.to_atom(key_mgmt),
-         ssid: System.get_env("NERVES_NETWORK_SSID"),
-         psk: System.get_env("NERVES_NETWORK_PSK")
+         networks: [
+           %{
+              key_mgmt: String.to_atom(key_mgmt),
+              ssid: System.get_env("NERVES_NETWORK_SSID"),
+              psk: System.get_env("NERVES_NETWORK_PSK")
+           }
+         ]
        },
        ipv4: %{method: :dhcp}
      }}


### PR DESCRIPTION
This fails to connect to WiFi because `VintageNetWiFi` now explicitly expects the `:networks` key.