### PR TITLE
Add more info to the sqlite example application

### DIFF
--- a/hello_sqlite/README.md
+++ b/hello_sqlite/README.md
@@ -3,6 +3,8 @@
 This example demonstrates a basic project for using the
 [Ecto SQLite Adapter](https://github.com/elixir-sqlite/ecto_sqlite3).
 
+See [scheduler_usage_poller.ex](hello_sqlite/lib/hello_sqlite/scheduler_usage_poller.ex) for an example of Sqlite being used.
+
 ## Hardware
 
 The example below assumes a Raspberry Pi 0 connected over the USB. Other

--- a/hello_sqlite/lib/hello_sqlite.ex
+++ b/hello_sqlite/lib/hello_sqlite.ex
@@ -1,18 +1,5 @@
 defmodule HelloSqlite do
-  @moduledoc """
-  Documentation for HelloSqlite.
-  """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> HelloSqlite.hello
-      :world
-
-  """
-  def hello do
-    :world
+  def save_scheduler_usage do
+    HelloSqlite.SchedulerUsagePoller.save_usage()
   end
 end

--- a/hello_sqlite/lib/hello_sqlite/scheduler_usage_poller.ex
+++ b/hello_sqlite/lib/hello_sqlite/scheduler_usage_poller.ex
@@ -1,8 +1,15 @@
 defmodule HelloSqlite.SchedulerUsagePoller do
+  @moduledoc """
+  Saves scheduler utilization to Sqlite every 30 seconds or whenever
+  `save_usage/1` is called.
+  """
+
   use GenServer
   require Logger
   alias HelloSqlite.{Repo, SchedulerUsage}
   import Ecto.Query
+
+  @timeout 30_000
 
   @doc """
   Pretty prints entries from the Scheduler Usage table
@@ -28,13 +35,33 @@ defmodule HelloSqlite.SchedulerUsagePoller do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
+  def save_usage do
+    GenServer.call(__MODULE__, :save_usage)
+  end
+
   @impl GenServer
   def init(_args) do
+    # A timeout of 0 is passed here so that we'll receive a `:timeout` message
+    # immediately after starting up
+    # More info: https://hexdocs.pm/elixir/GenServer.html#module-timeouts
     {:ok, nil, 0}
   end
 
   @impl GenServer
+  def handle_call(:save_usage, _from, state) do
+    do_save_usage()
+
+    {:reply, :ok, state, @timeout}
+  end
+
+  @impl GenServer
   def handle_info(:timeout, state) do
+    do_save_usage()
+
+    {:noreply, state, @timeout}
+  end
+
+  defp do_save_usage do
     util = :scheduler.utilization(1)
     {:total, total_util, total_percent_str} = :lists.keyfind(:total, 1, util)
     {total_percent, "%"} = Float.parse(to_string(total_percent_str))
@@ -44,7 +71,5 @@ defmodule HelloSqlite.SchedulerUsagePoller do
       total_util: total_util
     }
     |> Repo.insert!()
-
-    {:noreply, state, 30_000}
   end
 end


### PR DESCRIPTION
Make the GenServer easier to follow for developers who aren't as familiar with OTP (especially how the `handle_info(:timeout)`) is being invoked.

Add a note to the readme about the main file to look at to see sqlite actually being used.

Add code to hello_sqlite.ex that will eventually call sqlite.

Edit: I should probably note that I haven't actually tested this on a device, but I don't expect there to be any issues with the changes I made.