### PR TITLE
Add nerves logo to .iex.exs files

### DIFF
--- a/blinky/rootfs_overlay/etc/iex.exs
+++ b/blinky/rootfs_overlay/etc/iex.exs
@@ -1,3 +1,11 @@
+IO.puts("""
+\e[34m████▄▖    \e[36m▐███
+\e[34m█▌  ▀▜█▙▄▖  \e[36m▐█
+\e[34m█▌ \e[36m▐█▄▖\e[34m▝▀█▌ \e[36m▐█   \e[39mN  E  R  V  E  S
+\e[34m█▌   \e[36m▝▀█▙▄▖ ▐█
+\e[34m███▌    \e[36m▀▜████\e[0m
+""")
+
 # Add Toolshed helpers to the IEx session
 use Toolshed
 

--- a/hello_leds/rootfs_overlay/etc/iex.exs
+++ b/hello_leds/rootfs_overlay/etc/iex.exs
@@ -1,3 +1,11 @@
+IO.puts("""
+\e[34m████▄▖    \e[36m▐███
+\e[34m█▌  ▀▜█▙▄▖  \e[36m▐█
+\e[34m█▌ \e[36m▐█▄▖\e[34m▝▀█▌ \e[36m▐█   \e[39mN  E  R  V  E  S
+\e[34m█▌   \e[36m▝▀█▙▄▖ ▐█
+\e[34m███▌    \e[36m▀▜████\e[0m
+""")
+
 # Add Toolshed helpers to the IEx session
 use Toolshed
 

--- a/hello_phoenix/firmware/rootfs_overlay/etc/iex.exs
+++ b/hello_phoenix/firmware/rootfs_overlay/etc/iex.exs
@@ -1,3 +1,11 @@
+IO.puts("""
+\e[34m████▄▖    \e[36m▐███
+\e[34m█▌  ▀▜█▙▄▖  \e[36m▐█
+\e[34m█▌ \e[36m▐█▄▖\e[34m▝▀█▌ \e[36m▐█   \e[39mN  E  R  V  E  S
+\e[34m█▌   \e[36m▝▀█▙▄▖ ▐█
+\e[34m███▌    \e[36m▀▜████\e[0m
+""")
+
 # Add Toolshed helpers to the IEx session
 use Toolshed
 

--- a/hello_wifi/rootfs_overlay/etc/iex.exs
+++ b/hello_wifi/rootfs_overlay/etc/iex.exs
@@ -1,3 +1,11 @@
+IO.puts("""
+\e[34m████▄▖    \e[36m▐███
+\e[34m█▌  ▀▜█▙▄▖  \e[36m▐█
+\e[34m█▌ \e[36m▐█▄▖\e[34m▝▀█▌ \e[36m▐█   \e[39mN  E  R  V  E  S
+\e[34m█▌   \e[36m▝▀█▙▄▖ ▐█
+\e[34m███▌    \e[36m▀▜████\e[0m
+""")
+
 # Add Toolshed helpers to the IEx session
 use Toolshed
 

--- a/minimal/rootfs_overlay/etc/iex.exs
+++ b/minimal/rootfs_overlay/etc/iex.exs
@@ -1,3 +1,14 @@
+IO.puts("""
+\e[34m████▄▖    \e[36m▐███
+\e[34m█▌  ▀▜█▙▄▖  \e[36m▐█
+\e[34m█▌ \e[36m▐█▄▖\e[34m▝▀█▌ \e[36m▐█   \e[39mN  E  R  V  E  S
+\e[34m█▌   \e[36m▝▀█▙▄▖ ▐█
+\e[34m███▌    \e[36m▀▜████\e[0m
+""")
+
+# Add Toolshed helpers to the IEx session
+use Toolshed
+
 if RingLogger in Application.get_env(:logger, :backends, []) do
   IO.puts("""
   RingLogger is collecting log messages from Elixir and Linux. To see the


### PR DESCRIPTION
Some old examples do not have the Nerves logo in `.iex.exs`. The logo is so beautiful that there is a huge difference with or without it.

<img width="699" alt="Screen Shot 2021-05-02 at 10 17 41 AM" src="https://user-images.githubusercontent.com/7563926/116816369-a7164800-ab2f-11eb-9bcf-9f4818409692.png">