### PR TITLE
fix link in README for hello_sqlite

### DIFF
--- a/hello_sqlite/README.md
+++ b/hello_sqlite/README.md
@@ -3,7 +3,7 @@
 This example demonstrates a basic project for using the
 [Ecto SQLite Adapter](https://github.com/elixir-sqlite/ecto_sqlite3).
 
-See [scheduler_usage_poller.ex](hello_sqlite/lib/hello_sqlite/scheduler_usage_poller.ex) for an example of Sqlite being used.
+See [scheduler_usage_poller.ex](./lib/hello_sqlite/scheduler_usage_poller.ex) for an example of Sqlite being used.
 
 ## Hardware
 


### PR DESCRIPTION
Fix link to `scheduler_usage_poller.ex` in README