### PR TITLE
Fixes a typo in the `live_reload` config of `hello_live_view` example

### DIFF
--- a/hello_live_view/config/dev.exs
+++ b/hello_live_view/config/dev.exs
@@ -50,7 +50,7 @@ config :hello_live_view, HelloLiveViewWeb.Endpoint,
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
-      ~r"lib/hello_live_view_web/(live|views/components)/.*(ex)$",
+      ~r"lib/hello_live_view_web/(live|views|components)/.*(ex)$",
       ~r"lib/hello_live_view_web/templates/.*(eex)$"
     ]
   ]


### PR DESCRIPTION
I found a typo in the live reload config of the `hello_live_view` example that was ignoring changes to both views and components.