### PR TITLE
Elixir 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 elixir_version: &elixir_version
-  ELIXIR_VERSION: 1.14.3-otp-25
+  ELIXIR_VERSION: 1.14.3-otp-26
 
 defaults: &defaults
   working_directory: /nerves/build


### PR DESCRIPTION
TODO: find valid download URL. possibly not released yet as of now (June 13, 2023 at 8:46:12 AM EDT) ...