### PR TITLE
Add dependabot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ version: 2.1
 elixir_version: &elixir_version
   ELIXIR_VERSION: 1.15.6-otp-26
 
+targets: &targets
+  [rpi0, rpi, rpi2, rpi3, rpi3a, rpi4, bbb, osd32mp1, x86_64, grisp2, mangopi_mq_pro]
+
 defaults: &defaults
   working_directory: /nerves/build
   docker:
@@ -67,6 +70,25 @@ jobs:
       MIX_TARGET: << parameters.target >>
     <<: *build
 
+  automerge:
+    docker:
+        - image: alpine:3.18.4
+    <<: *defaults
+    steps:
+      - run:
+          name: Install GitHub CLI
+          command: apk add --no-cache build-base github-cli
+      - run:
+          name: Attempt PR automerge
+          command: |
+            author=$(gh pr view "${CIRCLE_PULL_REQUEST}" --json author --jq '.author.login' || true)
+
+            if [ "$author" = "app/dependabot" ]; then
+              gh pr merge "${CIRCLE_PULL_REQUEST}" --auto --rebase || echo "Failed trying to set automerge"
+            else
+              echo "Not a dependabot PR, skipping automerge"
+            fi
+
 workflows:
   build_collect:
     jobs:
@@ -75,4 +97,10 @@ workflows:
           <<: *context
           matrix:
             parameters:
-              target: [rpi0, rpi, rpi2, rpi3, rpi3a, rpi4, bbb, osd32mp1, x86_64, grisp2, mangopi_mq_pro]
+              target: *targets
+      - automerge:
+          requires: *targets
+          context: org-global
+          filters:
+            branches:
+              only: /^dependabot.*/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,182 @@
+version: 2
+
+updates:
+  - package-ecosystem: mix
+    directory: "/blinky"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_erlang"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_gpio"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_lfe"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_live_view"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_phoenix"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_snmp_agent"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_snmp_manager"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_sqlite"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_wifi"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/hello_zig"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"
+
+  - package-ecosystem: mix
+    directory: "/minimal"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      systems:
+        patterns:
+          - "nerves_system*"
+      deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nerves_system*"


### PR DESCRIPTION
For https://github.com/nerves-project/nerves/issues/918

Adds Dependabot to the project to keep examples up-to-date and a CI job which will auto merge the PR's created if CI passes