### PR TITLE
Fix Raspberry Pi, MangoPi, and GRiSP2 LED names

### DIFF
--- a/blinky/README.md
+++ b/blinky/README.md
@@ -34,7 +34,7 @@ the Raspberry Pi Zero's configuration looks like:
 config :blinky,
   indicators: %{
     default: %{
-      green: "led0"
+      green: "ACT"
     }
   }
 ```
@@ -43,7 +43,7 @@ This provides configuration for the demo application, `:blinky`. The atom
 `:indicators` is used by Delux to group LEDs that are controlled together. The
 Normally this would be a red, green, and blue LED, but the Raspberry Pi just has
 a green LED. For convenience, we tell Delux that the `:default` indicator has a
-`:green` LED. It's known to Linux as `"led0"`. You can find the names by listing
+`:green` LED. It's known to Linux as `"ACT"`. You can find the names by listing
 the `/sys/class/leds` directory.
 
 The second part of the demo is to add `Delux` to this project's supervision

--- a/blinky/config/grisp2.exs
+++ b/blinky/config/grisp2.exs
@@ -3,13 +3,13 @@ import Config
 
 # The GRiSP 2 has two RGB LEDs and a green LED
 #
-# RGB1: red:indicator-1, green:indicator-1, blue:indicator-1
-# RGB2: red:indicator-2, green:indicator-2, blue:indicator-2
+# RGB1: grisp-rgb1-red, grisp-rgb1-green, grisp-rgb1-blue
+# RGB2: grisp-rgb2-red, grisp-rgb2-green, grisp-rgb2-blue
 # phycore-green - defaults to heartbeat on boot
 
 config :blinky,
   indicators: %{
-    default: %{red: "red:indicator-1", green: "green:indicator-1", blue: "blue:indicator-1"},
-    rgb2: %{red: "red:indicator-2", green: "green:indicator-2", blue: "blue:indicator-2"},
+    default: %{red: "grisp-rgb1-red", green: "grisp-rgb1-green", blue: "grisp-rgb1-blue"},
+    rgb2: %{red: "grisp-rgb2-red", green: "grisp-rgb2-green", blue: "grisp-rgb2-blue"},
     phycore: %{green: "phycore-green"}
   }

--- a/blinky/config/mangopi_mq_pro.exs
+++ b/blinky/config/mangopi_mq_pro.exs
@@ -1,3 +1,3 @@
 import Config
 
-config :blinky, indicators: %{default: %{blue: ":status"}}
+config :blinky, indicators: %{default: %{blue: "blue:status"}}

--- a/blinky/config/rpi.exs
+++ b/blinky/config/rpi.exs
@@ -4,6 +4,6 @@ import Config
 config :blinky,
   indicators: %{
     default: %{
-      green: "led0"
+      green: "ACT"
     }
   }

--- a/blinky/config/rpi0.exs
+++ b/blinky/config/rpi0.exs
@@ -4,6 +4,6 @@ import Config
 config :blinky,
   indicators: %{
     default: %{
-      green: "led0"
+      green: "ACT"
     }
   }

--- a/blinky/config/rpi2.exs
+++ b/blinky/config/rpi2.exs
@@ -4,6 +4,6 @@ import Config
 config :blinky,
   indicators: %{
     default: %{
-      green: "led0"
+      green: "ACT"
     }
   }

--- a/blinky/config/rpi3.exs
+++ b/blinky/config/rpi3.exs
@@ -4,6 +4,6 @@ import Config
 config :blinky,
   indicators: %{
     default: %{
-      green: "led0"
+      green: "ACT"
     }
   }

--- a/blinky/config/rpi3a.exs
+++ b/blinky/config/rpi3a.exs
@@ -4,6 +4,6 @@ import Config
 config :blinky,
   indicators: %{
     default: %{
-      green: "led0"
+      green: "ACT"
     }
   }

--- a/blinky/config/rpi4.exs
+++ b/blinky/config/rpi4.exs
@@ -4,6 +4,6 @@ import Config
 config :blinky,
   indicators: %{
     default: %{
-      green: "led0"
+      green: "ACT"
     }
   }


### PR DESCRIPTION
Thanks to Jeff Morgan for reporting this.
