### PR TITLE
Update LiveView example docs and point people to it

### DIFF
--- a/hello_live_view/README.md
+++ b/hello_live_view/README.md
@@ -1,20 +1,12 @@
-Nerves + LiveView Example
-===
+# Nerves + LiveView Example
 
-This example shows a Nerves Project with a Pheonix/LiveView server embedded in the same application.  In contrast to
-a [poncho project](https://embedded-elixir.com/post/2017-05-19-poncho-projects/), there is only one application
-supervision tree containing the Phoenix Endpoint and any processes running on the device.
+This example shows a Nerves Project with a Phoenix server embedded in the same
+application.  In contrast to a [poncho
+project](https://embedded-elixir.com/post/2017-05-19-poncho-projects/), there is
+only one application supervision tree containing the Phoenix Endpoint and any
+processes running on the device.
 
-Currently the versions included are:
-
-* `nerves`  - 1.9.3
-* `phoenix`  - 1.7.2
-* `phoenix_liveview` - 0.18.18
-* `tailwindcss` - 0.2.0
-
-
-Configuration
----
+## Configuration
 
 The order of configuration is loaded in a specific order:
 
@@ -23,13 +15,11 @@ The order of configuration is loaded in a specific order:
 * `prod.exs`, `dev.exs`, or `test.exs` based on `MIX_ENV`
 * `runtime.exs` at runtime
 
-To make configuration slightly more straightforward, the application is run 
-with `MIX_ENV=prod` when on the device.  Therefore, the configuration for
-phoenix on the target device is in the `prod.exs` config file.
+To make configuration slightly more straightforward, the application is run with
+`MIX_ENV=prod` when on the device.  Therefore, the configuration for Phoenix on
+the target device is in the `prod.exs` config file.
 
-
-Developing
----
+## Developing
 
 You can start the application just like any Phoenix project:
 
@@ -37,9 +27,7 @@ You can start the application just like any Phoenix project:
 iex -S mix phx.server
 ```
 
-
-Flashing to a Device
----
+## Flashing to a Device
 
 You can burn the first image with the following commands:
 
@@ -50,8 +38,8 @@ MIX_ENV=prod MIX_TARGET=host mix do deps.get, assets.deploy
 MIX_ENV=prod MIX_TARGET=rpi3 mix do deps.get, firmware, burn
 ```
 
-Once the image is running on the device, the following will build and update the firmware
-over ssh.
+Once the image is running on the device, the following will build and update the
+firmware over ssh.
 
 ```bash
 # If you want to enable wifi:
@@ -60,30 +48,28 @@ MIX_ENV=prod MIX_TARGET=host mix do deps.get, assets.deploy
 MIX_ENV=prod MIX_TARGET=rpi3 mix do deps.get, firmware, upload your_app_name.local
 ```
 
+## Network Configuration
 
-Network Configuration
----
+The network and WiFi configuration are specified in the `target.exs` file.  In
+order to specify the network name and password, they must be set as environment
+variables `NERVES_SSID` `NERVES_PSK` at runtime.
 
-The network and WiFi configuration are specified in the `target.exs` file.  In order to
-specify the network name and password, they must be set as environment variables `NERVES_SSID`
-`NERVES_PSK` at runtime.
+If they are not specified, a warning will be printed when building firmware,
+which either gives you a chance to stop the build and add the environment
+variables or a clue as to why you are no longer able to access the device over
+WiFi.
 
-If they are not specified, a warning will be printed when building firmware, which either
-gives you a chance to stop the build and add the environment variables or a clue as to 
-why you are no longer able to access the device over WiFi.
+## Making It Your Own
 
-
-Making It Your Own
----
-
-To use this project as a start for your own Nerves/LiveView project, first replace the following strings throughout the project:
+To use this project as a start for your own Nerves/LiveView project, first
+replace the following strings throughout the project:
 
 * `HelloLiveView` -> `YourAppName`
 * `hello_live_view` -> `your_app_name`
 
 ```bash
 # Might be necessary in MacOS to avoid a sed "illegal byte sequence" error
-# export LC_CTYPE=C 
+# export LC_CTYPE=C
 # export LANG=C
 
 find . -type f \( -iname "*.ex*" ! -path "./deps/*" ! -path "./_build/*" \) -print0 | xargs -0 sed -i '' -e 's/HelloLiveView/YourAppName/g'
@@ -99,4 +85,3 @@ mv lib/hello_live_view_web lib/your_app_name_web
 mv lib/hello_live_view.ex lib/your_app_name.ex
 mv liv/hello_live_view_web.ex lib/your_app_name_web.ex
 ```
-

--- a/hello_phoenix/README.md
+++ b/hello_phoenix/README.md
@@ -8,6 +8,9 @@ You can read more about the motivations behind this concept on the
 embedded-elixir blog post about [Poncho Projects]. The steps for creating this
 example source are in [User Interfaces].
 
+See the `hello_live_view` for an all-in-one Phoenix/Nerves example that is much
+simpler to use for most people.
+
 ## Hardware
 
 This example serves a Phoenix-based web page over the network. The steps below


### PR DESCRIPTION
The poncho layout leads to a lot of code being written to move data
around between the Phoenix and hardware parts. Since this is a lot of
trouble for many projects, just point people over to the LiveView
example if they started looking in `hello_phoenix` first.
