### PR TITLE
Added target rpi0_2 for the Raspberry Pi Zero 2 W for blinky config.

### DIFF
--- a/blinky/config/rpi0_2.exs
+++ b/blinky/config/rpi0_2.exs
@@ -1,0 +1,9 @@
+# Configuration for the Raspberry Pi Zero 2 W (target rpi0_2)
+import Config
+
+config :blinky,
+  indicators: %{
+    default: %{
+      green: "ACT"
+    }
+  }


### PR DESCRIPTION
There are [prerequisites](https://github.com/nerves-livebook/nerves_livebook?tab=readme-ov-file#prerequisites) in [Nerves-livebook](https://github.com/nerves-livebook/nerves_livebook) page. Adding the Raspberry Pi Zero 2 W device target to the config should lead to consistency in the documentation and use it in `export MIX_TARGET=rpi0_2`.